### PR TITLE
Expose only public interface from flite crate

### DIFF
--- a/crates/flite/src/lexicon.rs
+++ b/crates/flite/src/lexicon.rs
@@ -7,7 +7,11 @@ use crate::{lts::Rules, Value};
 
 pub struct Lexicon(*mut cst_lexicon);
 
-pub static LEXICON: Lazy<Lexicon> = Lazy::new(|| unsafe { Lexicon::from_ptr(cmu_lex_init()) });
+static LEXICON: Lazy<Lexicon> = Lazy::new(|| unsafe { Lexicon::from_ptr(cmu_lex_init()) });
+
+pub fn lexicon() -> &'static Lexicon {
+    &LEXICON
+}
 
 impl Drop for Lexicon {
     fn drop(&mut self) {

--- a/crates/flite/src/lib.rs
+++ b/crates/flite/src/lib.rs
@@ -5,14 +5,14 @@ use flite_sys::{cst_val, delete_val, val_car, val_cdr, val_string};
 pub mod lexicon;
 pub mod lts;
 
-pub struct Value(*mut cst_val);
+pub(crate) struct Value(*mut cst_val);
 
-pub struct Val<'a> {
+pub(crate) struct Val<'a> {
     ptr: *const cst_val,
     _phantom: PhantomData<&'a ()>,
 }
 
-pub struct Iter<'a>(Val<'a>);
+pub(crate) struct Iter<'a>(Val<'a>);
 
 impl Drop for Value {
     fn drop(&mut self) {
@@ -25,10 +25,6 @@ impl Drop for Value {
 impl Value {
     pub const fn from_ptr(ptr: *mut cst_val) -> Self {
         Self(ptr)
-    }
-
-    pub const fn as_ptr(&self) -> *mut cst_val {
-        self.0
     }
 
     pub const fn iter(&self) -> Iter<'_> {

--- a/crates/kanatrans/src/adapter/processor/lex_lookup.rs
+++ b/crates/kanatrans/src/adapter/processor/lex_lookup.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use flite::lexicon::LEXICON;
+use flite::lexicon::lexicon;
 
 use crate::{
     adapter::command::Executor,
@@ -26,7 +26,7 @@ where
 
 impl Executor for LexLookupExecutor {
     fn execute(&self, word: &str) -> Result<Vec<String>> {
-        match LEXICON.lookup(&word.to_lowercase(), None) {
+        match lexicon().lookup(&word.to_lowercase(), None) {
             Ok(lexs) if lexs.is_empty() => bail!("cannot convert to ARPAbet"),
             Ok(lexs) => Ok(lexs),
             Err(e) => bail!(e),


### PR DESCRIPTION
This PR makes `flite::lexicon::LEXICON` private because it exposed its implementation detail. Instead `flite::lexicon::lexicon` is added to provide an access to a `&'static` reference to `Lexicon`.

Apart from stability of public interface, `flite::lexicon::LEXICON` can be refactored to use `std::cell::LazyCell<T>` in the upcoming release of Rust 1.80.
https://doc.rust-lang.org/std/cell/struct.LazyCell.html