### PR TITLE
Improve logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,7 @@ dependencies = [
  "domain",
  "serde",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/kanatrans-web-app/src/main.rs
+++ b/crates/kanatrans-web-app/src/main.rs
@@ -17,8 +17,6 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .with_timer(local_timer)
-        .with_file(true)
-        .with_line_number(true)
         .init();
 
     let arpabet_service = ArpabetService::new(LexLookup::new(LexLookupExecutor));

--- a/crates/server/src/router.rs
+++ b/crates/server/src/router.rs
@@ -7,8 +7,8 @@ use tokio::{
     net::TcpListener,
     signal::unix::{signal, SignalKind},
 };
-use tower_http::trace::{DefaultOnFailure, TraceLayer};
-use tracing::{Level, Span};
+use tower_http::trace::TraceLayer;
+use tracing::Span;
 
 use crate::{arpabet, katakana};
 
@@ -25,7 +25,7 @@ where
         .on_response(|response: &Response<_>, latency: Duration, _span: &Span| {
             tracing::info!("response {} in {latency:?}", response.status())
         })
-        .on_failure(DefaultOnFailure::new().level(Level::ERROR));
+        .on_failure(());
 
     let port = std::env::var("KANATRANS_PORT")
         .map_err(Error::from)

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -13,3 +13,6 @@ workspace = true
 
 [dependencies.thiserror]
 workspace = true
+
+[dependencies.tracing]
+workspace = true

--- a/crates/service/src/arpabet.rs
+++ b/crates/service/src/arpabet.rs
@@ -24,6 +24,7 @@ impl<Processor> ArpabetServiceInterface for ArpabetService<Processor>
 where
     Processor: Transcriber<Target: Deref<Target = [String]>> + Debug + Send + Sync + 'static,
 {
+    #[tracing::instrument(ret(level = tracing::Level::INFO), err)]
     async fn get(&self, word: String) -> Result<Arpabet, ServiceError> {
         let arpabet = self
             .transcriber

--- a/crates/service/src/katakana.rs
+++ b/crates/service/src/katakana.rs
@@ -23,6 +23,7 @@ impl<Processor> KatakanaServiceInterface for KatakanaService<Processor>
 where
     Processor: Transliterator<Target: Into<String>> + Debug + Send + Sync + 'static,
 {
+    #[tracing::instrument(ret(level = tracing::Level::INFO), err)]
     async fn get(&self, pronunciation: &[&str]) -> Result<Katakana, ServiceError> {
         let katakana =
             self.transliterator


### PR DESCRIPTION
The return values of service are log by tracing::instrument.
tracing::instrument logs also the error, and TraceLayer.on_failure is disabled instead.
