### PR TITLE
Add compatibility with WASI for flite

### DIFF
--- a/crates/flite-src/src/lib.rs
+++ b/crates/flite-src/src/lib.rs
@@ -54,8 +54,18 @@ impl Build {
         let mut configure = Command::new("./configure");
         configure
             .arg(format!("--prefix={}", &install_dir.to_str().unwrap()))
-            .arg("--with-audio=oss")
+            .arg("--with-audio=none")
             .current_dir(&inner_dir);
+
+        if env::var_os("CARGO_CFG_TARGET_OS").is_some_and(|os| os == "wasi") {
+            let wasi_sdk_path = env::var("WASI_SDK_PATH").unwrap();
+            configure
+                .arg("--host=wasm32-wasi")
+                .arg(format!("CC={wasi_sdk_path}/bin/clang"))
+                .arg(format!("AR={wasi_sdk_path}/bin/llvm-ar"))
+                .arg(format!("RANLIB={wasi_sdk_path}/bin/llvm-ranlib"));
+        }
+
         self.run_command(configure, "configuring flite");
 
         let mut install = Command::new("make");

--- a/crates/flite-src/src/lib.rs
+++ b/crates/flite-src/src/lib.rs
@@ -58,12 +58,15 @@ impl Build {
             .current_dir(&inner_dir);
 
         if env::var_os("CARGO_CFG_TARGET_OS").is_some_and(|os| os == "wasi") {
-            let wasi_sdk_path = env::var("WASI_SDK_PATH").unwrap();
+            let wasi_sdk_path = PathBuf::from(env::var_os("WASI_SDK_PATH").unwrap());
             configure
                 .arg("--host=wasm32-wasi")
-                .arg(format!("CC={wasi_sdk_path}/bin/clang"))
-                .arg(format!("AR={wasi_sdk_path}/bin/llvm-ar"))
-                .arg(format!("RANLIB={wasi_sdk_path}/bin/llvm-ranlib"));
+                .arg(format!("CC={}", wasi_sdk_path.join("bin/clang").to_str().unwrap()))
+                .arg(format!("AR={}", wasi_sdk_path.join("bin/llvm-ar").to_str().unwrap()))
+                .arg(format!(
+                    "RANLIB={}",
+                    wasi_sdk_path.join("bin/llvm-ranlib").to_str().unwrap()
+                ));
         }
 
         self.run_command(configure, "configuring flite");

--- a/crates/flite-sys/build.rs
+++ b/crates/flite-sys/build.rs
@@ -51,11 +51,14 @@ fn builder() -> Builder {
 
     match env::var_os("CARGO_CFG_TARGET_OS") {
         Some(os) if os == "wasi" => {
-            let wasi_sdk_path = env::var("WASI_SDK_PATH").unwrap();
+            let wasi_sdk_path = PathBuf::from(env::var_os("WASI_SDK_PATH").unwrap());
             let wasi_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
             builder.clang_args([
                 "-I",
-                &format!("{wasi_sdk_path}/share/wasi-sysroot/include/wasm32-wasi{wasi_env}"),
+                wasi_sdk_path
+                    .join(format!("share/wasi-sysroot/include/wasm32-wasi{wasi_env}"))
+                    .to_str()
+                    .unwrap(),
                 "-D",
                 "CST_NO_SOCKETS",
                 "-D",

--- a/crates/flite-sys/build.rs
+++ b/crates/flite-sys/build.rs
@@ -42,12 +42,31 @@ fn builder() -> Builder {
     artifacts.print_cargo_metadata();
 
     let include_dir = artifacts.include_dir();
-    bindgen::builder().header_contents("includes.h", INCLUDES).clang_args([
+    let builder = bindgen::builder().header_contents("includes.h", INCLUDES).clang_args([
         "-I",
         &include_dir.display().to_string(),
         "-I",
         &include_dir.join("flite").display().to_string(),
-    ])
+    ]);
+
+    match env::var_os("CARGO_CFG_TARGET_OS") {
+        Some(os) if os == "wasi" => {
+            let wasi_sdk_path = env::var("WASI_SDK_PATH").unwrap();
+            let wasi_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+            builder.clang_args([
+                "-I",
+                &format!("{wasi_sdk_path}/share/wasi-sysroot/include/wasm32-wasi{wasi_env}"),
+                "-D",
+                "CST_NO_SOCKETS",
+                "-D",
+                "DIE_ON_ERROR",
+                "-D",
+                "WASM32_WASI",
+                "-fvisibility=default",
+            ])
+        },
+        _ => builder,
+    }
 }
 
 #[cfg(not(feature = "vendored"))]


### PR DESCRIPTION
This PR adds compatibility with WASI for flite crate. The `WASI_SDK_PATH` must be set in order to build for WASI.

1. Install cargo-wasi:
   ```bash
   cargo install cargo-wasi
   ```
1. Download WASI SDK (at minimum version 22):
   ```bash
   curl -LOJ https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-23/wasi-sdk-23.0-x86_64-linux.tar.gz
   ```
1. Extract it to `WASI_SDK_PATH`:
   ```bash
   export WASI_SDK_PATH=/opt/wasi-sdk
   sudo mkdir -p "$WASI_SDK_PATH"
   sudo tar xzf wasi-sdk-23.0-x86_64-linux.tar.gz --strip-components=1 -C "$WASI_SDK_PATH"
   ```
1. Build flite with cargo-wasi:
   ```bash
   cargo wasi build --package=flite --features=vendored
   ```